### PR TITLE
Ajc split bam

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ CLASSIFIERS = [
 
 setup(
     name='sctools',
-    version='0.1.0',
+    version='0.1.4',
     description='Utilities for large-scale distributed single cell data processing',
-    url='https://github.com/humancellatlas/scsequtil.git',
+    url='https://github.com/humancellatlas/sctools.git',
     author='Ambrose J. Carr',
     author_email='mail@ambrosejcarr.com',
     package_dir={'': 'src'},
@@ -32,7 +32,8 @@ setup(
     ],
     entry_points={
             'console_scripts': [
-                'Attach10xBarcodes = sctools.platform:TenXV2.attach_barcodes'
+                'Attach10xBarcodes = sctools.platform:TenXV2.attach_barcodes',
+                'SplitBam = sctools.platform:GenericPlatform.split_bam'
             ]
     },
     classifiers=CLASSIFIERS,

--- a/src/sctools/barcode.py
+++ b/src/sctools/barcode.py
@@ -172,11 +172,9 @@ class ErrorsToCorrectBarcodesMap:
                 pysam.AlignmentFile(output_bam_file, 'wb', template=fin) as fout:
             for alignment in fin:
                 try:
-                    # pysam tags mimic tags in SAM specification -- they encode a two-
-                    # character tag (key), the type of the tag (Z = string), and the
-                    # tag value.
+                    # pysam tags mimic tags in SAM specification; Z = string
                     tag = self.get_corrected_barcode(alignment.get_tag('CR'))
-                    alignment.set_tag('CB', tag, 'Z')
-                except KeyError:
-                    pass  # code not in tag, just write the record as-is without a CB tag.
+                except KeyError:  # pass through the uncorrected barcode.
+                    tag = alignment.get_tag('CR')
+                alignment.set_tag(tag='CB', value=tag, value_type='Z')
                 fout.write(alignment)


### PR DESCRIPTION
This PR adds capability to split a BAM file (aligned or unaligned) by cell into chunks, specified by a target memory size (default = 1GB). 

It also fixes some comments from @samanehsan regarding an earlier PR for Cell barcode correction that got merged too early. 

The data in this PR match up with `sctools==0.1.4` on pypi and adds the `SplitBam` command line function. 

There is a related PR in [skylab](https://github.com/HumanCellAtlas/skylab/pull/51) that uses these tools. 