### PR TITLE
Add Dockerfile for sctools.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.6.2
+
+LABEL maintainer="Ambrose J. Carr <acarr@broadinstitute.org>" \
+  software="python 3.6.2" \
+  description="python 3.6.2 with pysam, sctools, requests, and a basic science stack"
+
+RUN pip3 install \
+    crimson==0.3.0 \
+    HTSeq==0.9.0 \
+    matplotlib==2.1.0 \
+    numpy==1.12.0 \
+    pandas==0.20.3 \
+    pysam==0.12.0.1 \
+    requests==2.18.4 \
+    scipy==0.18.1 \
+    tables==3.4.2
+
+WORKDIR usr/local/bin/sctools
+
+COPY . .
+
+RUN pip3 install .


### PR DESCRIPTION
Add a dockerfile for sctools in this PR, which is copied and modified from `skylab/docker/python3-scientific/Dockerfile`.