### PR TITLE
fix writing of reads without gene or cell records

### DIFF
--- a/src/sctools/metrics/writer.py
+++ b/src/sctools/metrics/writer.py
@@ -18,7 +18,9 @@ class MetricCSVWriter:
 
     def write(self, index: str, record: Mapping[str, Number]) -> None:
         ordered_fields = [str(record[k]) for k in self._header]
-        self._open_fid.write(index + ',' + ','.join(ordered_fields) + '\n')
+
+        # genes and cells can be None, include a repr() call to convert that to a string
+        self._open_fid.write(repr(index) + ',' + ','.join(ordered_fields) + '\n')
 
     def close(self) -> None:
         self._open_fid.close()


### PR DESCRIPTION
Can I get a rubber stamp here @jsotobroad ? 

The change that I made in the previous PR didn't account for how to write the record that has `None` instead of a `GE` tag. This PR fixes that by simply calling `repr()` on the index (gene or cell tag) prior to writing it. If the tag is a string, this operation does nothing. 