### PR TITLE
Add badge to report docs status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,10 @@ Single Cell Tools
 .. image:: https://codecov.io/gh/HumanCellAtlas/sctools/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/HumanCellAtlas/sctools
 
+.. image:: https://readthedocs.org/projects/sctools/badge/?version=latest
+  :target: https://sctools.readthedocs.io/en/latest/?badge=latest
+  :alt: Documentation Status
+
 Single Cell Tools provides utilities for manipulating sequence data formats suitable for use in
 distributed systems analyzing large biological datasets.
 

--- a/src/readthedocs.yml
+++ b/src/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: latest
+
+python:
+    version: 3.6

--- a/src/readthedocs.yml
+++ b/src/readthedocs.yml
@@ -3,3 +3,6 @@ build:
 
 python:
     version: 3.6
+
+requirements_file:
+    null

--- a/src/readthedocs.yml
+++ b/src/readthedocs.yml
@@ -1,8 +1,0 @@
-build:
-    image: latest
-
-python:
-    version: 3.6
-
-requirements_file:
-    null


### PR DESCRIPTION
The Sctools docs have been failing for 5 months. This change that problem more obvious!

Testing plan: Click "view" button on rendered `README.rst`, should display failing docs (unless I get the fix in before this gets reviewed). 