### PR TITLE
Make explicit that sctools does not support python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,7 @@ CLASSIFIERS = [
     "Natural Language :: English",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 


### PR DESCRIPTION
We don't support this. Remove lines from setup.py. 