### PR TITLE
changed the intermediate bam file writing of the SplitBam command Sam

### DIFF
--- a/src/sctools/bam.py
+++ b/src/sctools/bam.py
@@ -325,10 +325,9 @@ def write_barcodes_to_bins(
         for i in range(len(bins)):
             out_bam_name = os.path.join(f"{dirname}", f"{dirname}_{i}.bam")
             filepaths.append(out_bam_name)
-            # For now, bam writing uses one thread for compression. Better logic could support more processes without
-            # starving the machine for resources
+
             open_bam = pysam.AlignmentFile(
-                out_bam_name, "wb", template=input_alignments
+                out_bam_name, "w", template=input_alignments
             )
             files.append(open_bam)
 


### PR DESCRIPTION
In the SplitBamByCellBarcode the intermediate files were in BAM format. In this PR we change them to SAM format for faster writing.