### PR TITLE
NP change append to concat in GroupQCs

### DIFF
--- a/src/sctools/groups.py
+++ b/src/sctools/groups.py
@@ -69,7 +69,7 @@ def write_aggregated_picard_metrics_by_row(file_names, output_name):
         )
         df = pd.DataFrame.from_dict(metrics, orient="columns")
         df.insert(0, "Class", class_name)
-        d = d.append(df)
+        d = pd.concat([d, df])
     d_T = d.T
     d_T.to_csv(output_name + ".csv")
 


### PR DESCRIPTION
### Purpose

Since DataFrame.append() has been deprecated in pandas 2.2.2, we need to replace the append function is deprecated in the GroupQCs code. 

- No issue is linked to this PR.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- No changes.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
